### PR TITLE
require FileUtils

### DIFF
--- a/bin/nali
+++ b/bin/nali
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'fileutils'
 require 'nali/extensions'
 require 'nali/version'
 require 'nali/generator'


### PR DESCRIPTION
require FileUtils fix
shgz@S500:~/RubymineProjects$ nali new sample
/home/shgz/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/nali-0.4.0/lib/nali/generator.rb:21:in `create_application': uninitialized constant Nali::Generator::FileUtils (NameError)
    from /home/shgz/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/nali-0.4.0/lib/nali/generator.rb:7:in`initialize'
    from /home/shgz/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/nali-0.4.0/bin/nali:13:in `new'
    from /home/shgz/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/nali-0.4.0/bin/nali:13:in`<top (required)>'
    from /home/shgz/.rbenv/versions/2.2.0/bin/nali:23:in `load'
    from /home/shgz/.rbenv/versions/2.2.0/bin/nali:23:in`<main>'
